### PR TITLE
Fix trailing urls on android react native + season title prop

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -31,7 +31,7 @@ export class Client {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       this[endpointKey] = (params: Record<string, string>) =>
-        fetch(`${this.KODIK_API_URL}/${endpoint}?${new URLSearchParams({ token, ...params }).toString()}`, {
+        fetch(new URL(`${endpoint}?${new URLSearchParams({ token, ...params }).toString()}`,this.KODIK_API_URL), {
           method: 'POST',
         })
           .then(async (res) => {

--- a/src/resources/shared-types.ts
+++ b/src/resources/shared-types.ts
@@ -171,6 +171,7 @@ export interface EpisodesObject {
 
 export interface SeasonObject {
   link: string;
+  title?: string;
   episodes?: EpisodesObject;
 }
 

--- a/src/video-links.ts
+++ b/src/video-links.ts
@@ -139,7 +139,8 @@ export class VideoLinks {
     const { host, quality, ...parsed } = await VideoLinks.parseLink({ link });
 
     const url = new URL(
-      `https://${host}${videoInfoEndpoint}?${new URLSearchParams(parsed).toString()}`
+      `${videoInfoEndpoint}?${new URLSearchParams(parsed).toString()}`,
+      `https://${host}`
     );
     const videoInfoResponse = await fetch(url);
     if (videoInfoResponse.headers.get('content-type') !== 'application/json')


### PR DESCRIPTION
имплементация new URL на андроидовском реакте другая из-за чего появляется лишний слэш который выдает 404.
Например
`https://kodik.info/ftor?hash=fec5c553b13aec30c46f482c97e20f5c&id=604651&type=seria`
`https://kodik.info/ftor?hash=fec5c553b13aec30c46f482c97e20f5c&id=604651&type=seria/`
дают разные отыеты

Добавил проп названия в сезоны, тк там есть иногда названия для сезонов, например
`https://kodikapi.com/search?with_episodes=true&episode=3&shikimori_id=10588&token=`